### PR TITLE
Expose functionality for specifying rootUrl in advance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-Taskcluster URL Building Library
-================================
+# Taskcluster URL Building Library
 
 [![Build Status](https://travis-ci.org/taskcluster/taskcluster-lib-urls.svg?branch=master)](https://travis-ci.org/taskcluster/taskcluster-lib-urls)
 [![npm](https://img.shields.io/npm/v/taskcluster-lib-urls.svg?maxAge=2592000)](https://www.npmjs.com/package/taskcluster-lib-urls)
 [![License](https://img.shields.io/badge/license-MPL%202.0-orange.svg)](http://mozilla.org/MPL/2.0)
 
-A simple library to generate urls for various Taskcluster resources across our various deployment methods.
+A simple library to generate URLs for various Taskcluster resources across our various deployment methods.
 
-This serves as both a simple shim for projects that use javascript but also is the reference implementation for
+This serves as both a simple shim for projects that use JavaScript but also is the reference implementation for
 how we define these paths.
 
 Changelog
@@ -17,31 +16,50 @@ View the changelog on the [releases page](https://github.com/taskcluster/taskclu
 Requirements
 ------------
 
-This is tested on and should run on any of node `{8, 10}`.
+This is tested on and should run on any of Node.js `{8, 10}`.
 
 Usage
 -----
 
-This package exports 3 methods:
+This package exports several methods for generating URLs conditionally based on
+a root URL, as well as a few helper classes for generating URLs for a pre-determined
+root URL:
 
-* `api(rootUrl, service, version, path)`
-* `schema(rootUrl, service, version, schema)`
-* `apiReference(rootUrl, service, version)`
-* `exchangeReference(rootUrl, service, version)`
-* `ui(rootUrl, path)`
-* `docs(rootUrl, path)`
+* `api(rootUrl, service, version, path)` -> `String`
+* `apiReference(rootUrl, service, version)` -> `String`
+* `docs(rootUrl, path)` -> `String`
+* `exchangeReference(rootUrl, service, version)` -> `String`
+* `schema(rootUrl, service, version, schema)` -> `String`
+* `ui(rootUrl, path)` -> `String`
+* `withRootUrl(rootUrl)` -> `Class` instance for above methods
 
-When the `rootUrl` is `https://taskcluster.net`, the generated urls will be to the Heroku cluster. Otherwise they will follow the
+When the `rootUrl` is `https://taskcluster.net`, the generated URLs will be to the Heroku cluster. Otherwise they will follow the
 [spec defined in this project](https://github.com/taskcluster/taskcluster-lib-urls/tree/master/docs/urls-spec.md).
 
 ```js
+// Specifying root URL every time:
 const tcUrl = require('taskcluster-lib-url');
+
 tcUrl.api(rootUrl, 'auth', 'v1', 'foo/bar');
 tcUrl.schema(rootUrl, 'auth', 'v1', 'foo.yml');
 tcUrl.apiReference(rootUrl, 'auth', 'v1');
 tcUrl.exchangeReference(rootUrl, 'auth', 'v1');
 tcUrl.ui(rootUrl, 'foo/bar');
 tcUrl.docs(rootUrl, 'foo/bar');
+```
+
+```js
+// Specifying root URL in advance:
+const tcUrl = require('taskcluster-lib-url');
+
+const urls = tcUrl.withRoot(rootUrl);
+
+urls.api('auth', 'v1', 'foo/bar');
+urls.schema('auth', 'v1', 'foo.yml');
+urls.apiReference('auth', 'v1');
+urls.exchangeReference('auth', 'v1');
+urls.ui('foo/bar');
+urls.docs('foo/bar');
 ```
 
 Testing

--- a/src/index.js
+++ b/src/index.js
@@ -3,66 +3,165 @@ const TASKCLUSTER_NET = 'https://taskcluster.net';
 const cleanRoot = rootUrl => rootUrl.replace(/\/$/, '');
 const cleanPath = path => path.replace(/^\//, '');
 
-/**
- * Generate url for path in the Taskcluster docs website.
- */
-exports.docs = (rootUrl, path) => {
-  rootUrl = cleanRoot(rootUrl);
-  path = cleanPath(path);
-  return rootUrl === TASKCLUSTER_NET ?
-    `https://docs.taskcluster.net/${path}` :
-    `${rootUrl}/docs/${path}`;
-};
+class LegacyUrls {
+  /**
+   * Generate URL for path in a Taskcluster service.
+   */
+  api(service, version, path) {
+    return `https://${service}.taskcluster.net/${version}/${cleanPath(path)}`;
+  }
 
-/**
- * Generate url for path in a Taskcluster service.
- */
-exports.api = (rootUrl, service, version, path) => {
-  rootUrl = cleanRoot(rootUrl);
-  path = cleanPath(path);
-  return rootUrl === TASKCLUSTER_NET ?
-    `https://${service}.taskcluster.net/${version}/${path}` :
-    `${rootUrl}/api/${service}/${version}/${path}`;
-};
+  /**
+   * Generate URL for the api reference of a Taskcluster service.
+   */
+  apiReference(service, version) {
+    return `https://references.taskcluster.net/${service}/${version}/api.json`;
+  }
 
-/**
- * Generate url for the schemas of a Taskcluster service.
- */
-exports.schema = (rootUrl, service, version, schema) => {
-  rootUrl = cleanRoot(rootUrl);
-  schema = cleanPath(schema);
-  return rootUrl === TASKCLUSTER_NET ?
-    `https://schemas.taskcluster.net/${service}/${version}/${schema}` :
-    `${rootUrl}/schemas/${service}/${version}/${schema}`;
-};
+  /**
+   * Generate URL for path in the Taskcluster docs website.
+   */
+  docs(path) {
+    return `https://docs.taskcluster.net/${cleanPath(path)}`;
+  }
 
-/**
- * Generate url for the api reference of a Taskcluster service.
- */
-exports.apiReference = (rootUrl, service, version) => {
-  rootUrl = cleanRoot(rootUrl);
-  return rootUrl === TASKCLUSTER_NET ?
-    `https://references.taskcluster.net/${service}/${version}/api.json` :
-    `${rootUrl}/references/${service}/${version}/api.json`;
-};
+  /**
+   * Generate URL for the exchange reference of a Taskcluster service.
+   */
+  exchangeReference(service, version) {
+    return `https://references.taskcluster.net/${service}/${
+      version
+    }/exchanges.json`;
+  }
 
-/**
- * Generate url for the exchange reference of a Taskcluster service.
- */
-exports.exchangeReference = (rootUrl, service, version) => {
-  rootUrl = cleanRoot(rootUrl);
-  return rootUrl === TASKCLUSTER_NET ?
-    `https://references.taskcluster.net/${service}/${version}/exchanges.json` :
-    `${rootUrl}/references/${service}/${version}/exchanges.json`;
-};
+  /**
+   * Generate URL for the schemas of a Taskcluster service.
+   */
+  schema(service, version, schema) {
+    return `https://schemas.taskcluster.net/${service}/${version}/${
+      cleanPath(schema)
+    }`;
+  }
 
-/**
- * Generate url for Taskcluser UI.
- */
-exports.ui = (rootUrl, path) => {
-  rootUrl = cleanRoot(rootUrl);
-  path = cleanPath(path);
-  return rootUrl === TASKCLUSTER_NET ?
-    `https://tools.taskcluster.net/${path}` :
-    `${rootUrl}/${path}`;
+  /**
+   * Generate URL for Taskcluser UI.
+   */
+  ui(path) {
+    return `https://tools.taskcluster.net/${cleanPath(path)}`;
+  }
+}
+
+class Urls {
+  constructor(rootUrl) {
+    this.rootUrl = cleanRoot(rootUrl);
+  }
+
+  /**
+   * Generate URL for path in a Taskcluster service.
+   */
+  api(service, version, path) {
+    return `${this.rootUrl}/api/${service}/${version}/${cleanPath(path)}`;
+  }
+
+  /**
+   * Generate URL for the api reference of a Taskcluster service.
+   */
+  apiReference(service, version) {
+    return `${this.rootUrl}/references/${service}/${version}/api.json`;
+  }
+
+  /**
+   * Generate URL for path in the Taskcluster docs website.
+   */
+  docs(path) {
+    return `${this.rootUrl}/docs/${cleanPath(path)}`;
+  }
+
+  /**
+   * Generate URL for the exchange reference of a Taskcluster service.
+   */
+  exchangeReference(service, version) {
+    return `${this.rootUrl}/references/${service}/${version}/exchanges.json`;
+  }
+
+  /**
+   * Generate URL for the schemas of a Taskcluster service.
+   */
+  schema(service, version, schema) {
+    return `${this.rootUrl}/schemas/${service}/${version}/${schema}`;
+  }
+
+  /**
+   * Generate URL for Taskcluser UI.
+   */
+  ui(path) {
+    return `${this.rootUrl}/${cleanPath(path)}`;
+  }
+}
+
+const withRootUrl = rootUrl =>
+  cleanRoot(rootUrl) === TASKCLUSTER_NET ?
+    new LegacyUrls() :
+    new Urls(rootUrl);
+
+module.exports = {
+  /**
+   * Generate URLs for redeployable services and entities from
+   * an initial root URL.
+   */
+  Urls,
+
+  /**
+   * Generate URLs for legacy services and entities like Heroku
+   * from an initial root URL.
+   */
+  LegacyUrls,
+
+  /**
+   * Generate URLs for either redeployable or legacy services and entities
+   * from an initial root URL.
+   */
+  withRootUrl,
+
+  /**
+   * Generate URL for path in a Taskcluster service.
+   */
+  api(rootUrl, service, version, path) {
+    return withRootUrl(rootUrl).api(service, version, path);
+  },
+
+  /**
+   * Generate URL for the api reference of a Taskcluster service.
+   */
+  apiReference(rootUrl, service, version) {
+    return withRootUrl(rootUrl).apiReference(service, version);
+  },
+
+  /**
+   * Generate URL for path in the Taskcluster docs website.
+   */
+  docs(rootUrl, path) {
+    return withRootUrl(rootUrl).docs(path);
+  },
+
+  /**
+   * Generate URL for the exchange reference of a Taskcluster service.
+   */
+  exchangeReference(rootUrl, service, version) {
+    return withRootUrl(rootUrl).exchangeReference(service, version);
+  },
+
+  /**
+   * Generate URL for the schemas of a Taskcluster service.
+   */
+  schema(rootUrl, service, version, schema) {
+    return withRootUrl(rootUrl).schema(service, version, schema);
+  },
+
+  /**
+   * Generate URL for Taskcluser UI.
+   */
+  ui(rootUrl, path) {
+    return withRootUrl(rootUrl).ui(path);
+  },
 };


### PR DESCRIPTION
I refactored a few things to make it possible to specify a `rootUrl` in advance. It is still possible to, using the exported functions, calculate any URL at the desired time from a `rootUrl`, but I have exposed an additional method `withRootUrl` and it's helper classes to provide a `rootUrl` in advance so it would be possible to generate these methods but only have to consume `TASKCLUSTER_ROOT_URL` once in an app.

For example, this makes it possible to:

```js
import { withRootUrl } from 'taskcluster-lib-urls';

module.exports = withRootUrl(process.env.TASKCLUSTER_ROOT_URL);
```

```js
import urls from './urls';

console.log(urls.api('auth', 'v1', 'foo/bar'));
```

...any keep the consumption of an environment variable to a single location.

Thoughts?