### PR TITLE
Bug 1468606 - add servicesManifest method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ jspm_packages
 # Optional npm cache directory
 .npm
 
+# npm package lock file
+package-lock.json
+
 # Optional REPL history
 .node_repl_history
 

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -2,7 +2,6 @@
   "Enable": [
     "deadcode",
     "errcheck",
-    "gas",
     "goconst",
     "goimports",
     "golint",

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -24,7 +24,7 @@ tasks:
         - "-lc"
         - "git clone {{event.head.repo.url}} repo && cd repo && git checkout {{event.head.sha}} && yarn install && yarn test"
     metadata:
-      name: "taskcluster-lib-urls test"
+      name: "taskcluster-lib-urls node.js test"
       description: "Library for building taskcluster urls"
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"
@@ -87,7 +87,7 @@ tasks:
           gometalinter --install &&
           gometalinter
     metadata:
-      name: taskcluster-lib-urls go test
+      name: "taskcluster-lib-urls go test"
       description: Run library test suite - golang 1.10
       owner: '{{ event.head.user.email }}'
       source: '{{ event.head.repo.url }}'
@@ -114,7 +114,7 @@ tasks:
           pip install tox &&
           tox -e py27
     metadata:
-      name: taskcluster-lib-urls python 2.7 test
+      name: "taskcluster-lib-urls python 2.7 test"
       description: Run library test suite - python2.7
       owner: '{{ event.head.user.email }}'
       source: '{{ event.head.repo.url }}'

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ root URL:
 * `exchangeReference(rootUrl, service, version)` -> `String`
 * `schema(rootUrl, service, schema)` -> `String`
 * `ui(rootUrl, path)` -> `String`
+* `servicesManifest(rootUrl)` -> `String`
 * `testRootUrl()` -> `String`
 * `withRootUrl(rootUrl)` -> `Class` instance for above methods
 
@@ -50,6 +51,7 @@ libUrls.schema(rootUrl, 'auth', 'v1/foo.yml'); // Note that schema names have ve
 libUrls.apiReference(rootUrl, 'auth', 'v1');
 libUrls.exchangeReference(rootUrl, 'auth', 'v1');
 libUrls.ui(rootUrl, 'foo/bar');
+libUrls.servicesManifest(rootUrl);
 libUrls.docs(rootUrl, 'foo/bar');
 ```
 
@@ -64,6 +66,7 @@ urls.schema('auth', 'v1/foo.yml');
 urls.apiReference('auth', 'v1');
 urls.exchangeReference('auth', 'v1');
 urls.ui('foo/bar');
+urls.servicesManifest();
 urls.docs('foo/bar');
 ```
 
@@ -90,6 +93,7 @@ func Docs(rootURL string, path string) string
 func ExchangeReference(rootURL string, service string, version string) string
 func Schema(rootURL string, service string, name string) string
 func UI(rootURL string, path string) string
+func ServicesManifest(rootURL string) string
 ```
 
 Python Usage
@@ -105,6 +109,7 @@ taskcluster_urls.schema(root_url, 'auth', 'v1/foo.yml') # Note that schema names
 taskcluster_urls.api_reference(root_url, 'auth', 'v1')
 taskcluster_urls.exchange_reference(root_url, 'auth', 'v1')
 taskcluster_urls.ui(root_url, 'foo/bar')
+taskcluster_urls.servicesManifest(root_url)
 taskcluster_urls.docs(root_url, 'foo/bar')
 ```
 

--- a/docs/urls-spec.md
+++ b/docs/urls-spec.md
@@ -25,6 +25,7 @@ Taskcluster uses URLs with the following pattern:
 | exchangeReference(rootUrl, service, version) | `<rootUrl>/references/<service>/<version>/exchanges.json` |
 | schema(rootUrl, service, schema) | `<rootUrl>/schemas/<service>/<schema>` |
 | ui(rootUrl, path) | `<rootUrl>/<path>` |
+| servicesManifest(rootUrl) | `<rootUrl>/references/manifest.json` |
 
 *NOTE*: you should *always* use this library to generate URLs, rather than
 hard-coding any of the above patterns.

--- a/specification.yml
+++ b/specification.yml
@@ -64,3 +64,8 @@ specs:
   argSets:
   - ['']
   - [/]
+- type: servicesManifest
+  expectedUrl: https://taskcluster.example.com/references/manifest.json
+  oldExpectedUrl: https://references.taskcluster.net/manifest.json
+  argSets:
+  - []

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,13 @@ class LegacyUrls {
   ui(path) {
     return `https://tools.taskcluster.net/${cleanPath(path)}`;
   }
+
+  /**
+   * Returns a URL for the service manifest of a taskcluster deployment.
+   */
+  servicesManifest() {
+    return 'https://references.taskcluster.net/manifest.json';
+  }
 }
 
 class Urls {
@@ -99,6 +106,13 @@ class Urls {
    */
   ui(path) {
     return `${this.rootUrl}/${cleanPath(path)}`;
+  }
+
+  /**
+   * Returns a URL for the service manifest of a taskcluster deployment.
+   */
+  servicesManifest() {
+    return `${this.rootUrl}/references/manifest.json`;
   }
 }
 
@@ -166,6 +180,13 @@ module.exports = {
    */
   ui(rootUrl, path) {
     return withRootUrl(rootUrl).ui(path);
+  },
+
+  /**
+   * Returns a URL for the service manifest of a taskcluster deployment.
+   */
+  servicesManifest(rootUrl) {
+    return withRootUrl(rootUrl).servicesManifest();
   },
 
   /**

--- a/taskcluster_urls/__init__.py
+++ b/taskcluster_urls/__init__.py
@@ -51,3 +51,11 @@ def ui(root_url, path):
         return 'https://tools.taskcluster.net/{}'.format(path)
     else:
         return '{}/{}'.format(root_url, path)
+
+def services_manifest(root_url):
+    """Returns a URL for the service manifest of a taskcluster deployment."""
+    root_url = root_url.rstrip('/')
+    if root_url == OLD_ROOT_URL:
+        return 'https://references.taskcluster.net/manifest.json'
+    else:
+        return '{}/references/manifest.json'.format(root_url)

--- a/tcurls.go
+++ b/tcurls.go
@@ -70,3 +70,13 @@ func UI(rootURL string, path string) string {
 		return fmt.Sprintf("%s/%s", r, path)
 	}
 }
+
+// ServicesManifest returns a URL for the service manifest of a taskcluster deployment
+func ServicesManifest(rootURL string) string {
+	switch r := strings.TrimRight(rootURL, "/"); r {
+	case oldRootURL:
+		return "https://references.taskcluster.net/manifest.json"
+	default:
+		return fmt.Sprintf("%s/references/manifest.json", r)
+	}
+}


### PR DESCRIPTION
See [bug 1468606](https://bugzil.la/1468606) for more context.

I've added a new method that returns the `manifest.json` file for a given taskcluster root url.

At the same time I added some green ticks to the go tests, since I like the ones that `npm test` produces. 😉 

Thanks!