### PR TITLE
Bug 1492543 - Treat leading/trailing slashes equivalently between implementations

### DIFF
--- a/specification.yml
+++ b/specification.yml
@@ -17,13 +17,13 @@ specs:
   oldExpectedUrl: https://auth.taskcluster.net/v1/ping
   argSets:
   - [auth, v1, ping]
-  - [auth, v1, /ping]
+  - [auth, v1, //ping]
 - type: api
   expectedUrl: https://taskcluster.example.com/api/auth/v1/foo/ping
   oldExpectedUrl: https://auth.taskcluster.net/v1/foo/ping
   argSets:
   - [auth, v1, foo/ping]
-  - [auth, v1, /foo/ping]
+  - [auth, v1, //foo/ping]
 - type: docs
   expectedUrl: https://taskcluster.example.com/docs/something/in/docs
   oldExpectedUrl: https://docs.taskcluster.net/something/in/docs

--- a/src/test/java/org/mozilla/taskcluster/urls/URLsTest.java
+++ b/src/test/java/org/mozilla/taskcluster/urls/URLsTest.java
@@ -11,10 +11,10 @@ import org.yaml.snakeyaml.Yaml;
 
 public class URLsTest {
 
-    private final static String[] oldRootURLs = new String[] { "https://taskcluster.net", "https://taskcluster.net/" };
+    private final static String[] oldRootURLs = new String[] { "https://taskcluster.net", "https://taskcluster.net//" };
 
     private final static String[] newRootURLs = new String[] { "https://taskcluster.example.com",
-            "https://taskcluster.example.com/" };
+            "https://taskcluster.example.com//" };
 
     /**
      * greenTick is an ANSI byte sequence to render a light green tick in a

--- a/tcurls_test.go
+++ b/tcurls_test.go
@@ -67,7 +67,7 @@ func TestURLs(t *testing.T) {
 				t.Errorf("URL is not correct. Got %q wanted %q", result, test.ExpectedURL)
 				continue
 			}
-			result, err = testFunc(t, test.FunctionType, fmt.Sprintf("%s/", rootURL), argSet...)
+			result, err = testFunc(t, test.FunctionType, fmt.Sprintf("%s//", rootURL), argSet...)
 			if err != nil {
 				t.Error(err)
 			}
@@ -85,7 +85,7 @@ func TestURLs(t *testing.T) {
 			if result != test.OldExpectedURL {
 				t.Errorf("URL is not correct. Got %q wanted %q", result, test.OldExpectedURL)
 			}
-			result, err = testFunc(t, test.FunctionType, fmt.Sprintf("%s/", oldRootURL), argSet...)
+			result, err = testFunc(t, test.FunctionType, fmt.Sprintf("%s//", oldRootURL), argSet...)
 			if err != nil {
 				t.Error(err)
 			}

--- a/test/basic_test.js
+++ b/test/basic_test.js
@@ -14,11 +14,11 @@ suite('basic test', function() {
 
     test(expectedUrl, function() {
       const w = libUrls.withRootUrl(ROOT_URL);
-      const ws = libUrls.withRootUrl(ROOT_URL + '/');
+      const ws = libUrls.withRootUrl(ROOT_URL + '//');
 
       argSets.forEach(args => {
         assert.equal(expectedUrl, libUrls[type](ROOT_URL, ...args));
-        assert.equal(expectedUrl, libUrls[type](ROOT_URL + '/', ...args));
+        assert.equal(expectedUrl, libUrls[type](ROOT_URL + '//', ...args));
         assert.equal(expectedUrl, w[type](...args));
         assert.equal(expectedUrl, ws[type](...args));
       });
@@ -26,11 +26,11 @@ suite('basic test', function() {
 
     test(oldExpectedUrl, function() {
       const w = libUrls.withRootUrl(OLD_ROOT_URL);
-      const ws = libUrls.withRootUrl(OLD_ROOT_URL + '/');
+      const ws = libUrls.withRootUrl(OLD_ROOT_URL + '//');
 
       argSets.forEach(args => {
         assert.equal(oldExpectedUrl, libUrls[type](OLD_ROOT_URL, ...args));
-        assert.equal(oldExpectedUrl, libUrls[type](OLD_ROOT_URL + '/', ...args));
+        assert.equal(oldExpectedUrl, libUrls[type](OLD_ROOT_URL + '//', ...args));
         assert.equal(oldExpectedUrl, w[type](...args));
         assert.equal(oldExpectedUrl, ws[type](...args));
       });

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -25,7 +25,7 @@ def pytest_generate_tests(metafunc):
 
 
 def test_basic(func, args, expected_url, old_expected_url):
-    assert func(ROOT_URL + '/', *args) == expected_url
+    assert func(ROOT_URL + '//', *args) == expected_url
     assert func(ROOT_URL, *args) == expected_url
-    assert func(OLD_ROOT_URL + '/', *args) == old_expected_url
+    assert func(OLD_ROOT_URL + '//', *args) == old_expected_url
     assert func(OLD_ROOT_URL, *args) == old_expected_url


### PR DESCRIPTION
I spotted that python/go are stripping multiple slashes, whereas java/javascript implementations are stripping only a single forward slash in both cases.

This PR has two commits - the first updates the tests to demonstrate the problem, the second commit adjusts the java and javascript implementations to be consistent with the python/go implementations (I arbitrarily chose for the python/go implementation to be correct). :-)