### PR TITLE
Add task inspector url

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ class LegacyUrls {
    * Returns a link to the task group or the task in Task Inspector
    */
   taskInspector(taskGroupId, taskId) {
-    let taskDetails = taskId ? `/tasks/${taskId}/details` : '';
+    let taskDetails = taskId ? `/tasks/${taskId}/runs/0/logs/public/logs/live.log` : '';
     return 'https://tools.taskcluster.net/groups/' + taskGroupId + taskDetails;
   }
 }
@@ -126,8 +126,8 @@ class Urls {
    * Returns a link to the task group or the task in Task Inspector
    */
   taskInspector(taskGroupId, taskId) {
-    let taskDetails = taskId ? `/tasks/${taskId}/details` : '';
-    return `${this.rootUrl}/groups/${taskGroupId}${taskDetails}`;
+    let taskLog = taskId ? `/tasks/${taskId}/runs/0/logs/public/logs/live.log` : '';
+    return `${this.rootUrl}/groups/${taskGroupId}${taskLog}`;
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ class LegacyUrls {
    */
   taskInspector(taskGroupId, taskId) {
     let taskDetails = taskId ? `/tasks/${taskId}/runs/0/logs/public/logs/live.log` : '';
-    return 'https://tools.taskcluster.net/groups/' + taskGroupId + taskDetails;
+    return this.ui(`groups/${taskGroupId}${taskDetails}`);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,14 @@ class LegacyUrls {
   servicesManifest() {
     return 'https://references.taskcluster.net/manifest.json';
   }
+
+  /**
+   * Returns a link to the task group or the task in Task Inspector
+   */
+  taskInspector(taskGroupId, taskId) {
+    let taskDetails = taskId ? `/tasks/${taskId}/details` : '';
+    return 'https://tools.taskcluster.net/groups/' + taskGroupId + taskDetails;
+  }
 }
 
 class Urls {
@@ -112,6 +120,14 @@ class Urls {
    */
   servicesManifest() {
     return `${this.rootUrl}/references/manifest.json`;
+  }
+
+  /**
+   * Returns a link to the task group or the task in Task Inspector
+   */
+  taskInspector(taskGroupId, taskId) {
+    let taskDetails = taskId ? `/tasks/${taskId}/details` : '';
+    return `${this.rootUrl}/groups/${taskGroupId}${taskDetails}`;
   }
 }
 
@@ -186,6 +202,20 @@ module.exports = {
    */
   servicesManifest(rootUrl) {
     return withRootUrl(rootUrl).servicesManifest();
+  },
+
+  /**
+   * Method for generating links to task group or a task in Task Inspector
+   *
+   * @param rootUrl - string; rootUrl of the Taskcluster deployment,
+   *                  expected to be without a trailing slash
+   * @param taskGroupId - string
+   * @param taskId - string. Optional
+   *
+   * @returns string. URL to the task group (or the task if that parameter was also given) in Task Inspector
+   */
+  taskInspector(rootUrl, taskGroupId, taskId) {
+    return withRootUrl(rootUrl).taskInspector(taskGroupId, taskId);
   },
 
   /**

--- a/src/main/java/org/mozilla/taskcluster/urls/LegacyURLs.java
+++ b/src/main/java/org/mozilla/taskcluster/urls/LegacyURLs.java
@@ -54,4 +54,18 @@ public class LegacyURLs implements URLProvider {
     public String servicesManifest() {
         return "https://references.taskcluster.net/manifest.json";
     }
+
+    /**
+     * Returns a link to the task group in Task Inspector
+     */
+    public String taskInspector(String taskGroupId) {
+        return "https://tools.taskcluster.net/groups/" + taskGroupId;
+    }
+
+    /**
+     * Returns a link to the task in Task Inspector
+     */
+    public String taskInspector(String taskGroupId, String taskId) {
+        return "https://tools.taskcluster.net/groups/" + taskGroupId + "/tasks/" + taskId + "/details";
+    }
 }

--- a/src/main/java/org/mozilla/taskcluster/urls/LegacyURLs.java
+++ b/src/main/java/org/mozilla/taskcluster/urls/LegacyURLs.java
@@ -67,7 +67,7 @@ public class LegacyURLs implements URLProvider {
      */
     @Override
     public String taskInspector(String taskGroupId) {
-        return "https://tools.taskcluster.net/groups/" + taskGroupId;
+        return this.ui("groups/" + taskGroupId);
     }
 
     /**
@@ -75,6 +75,6 @@ public class LegacyURLs implements URLProvider {
      */
     @Override
     public String taskInspector(String taskGroupId, String taskId) {
-        return "https://tools.taskcluster.net/groups/" + taskGroupId + "/tasks/" + taskId + "/runs/0/logs/public/logs/live.log";
+        return this.ui(groups/" + taskGroupId + "/tasks/" + taskId + "/runs/0/logs/public/logs/live.log");
     }
 }

--- a/src/main/java/org/mozilla/taskcluster/urls/LegacyURLs.java
+++ b/src/main/java/org/mozilla/taskcluster/urls/LegacyURLs.java
@@ -75,6 +75,6 @@ public class LegacyURLs implements URLProvider {
      */
     @Override
     public String taskInspector(String taskGroupId, String taskId) {
-        return "https://tools.taskcluster.net/groups/" + taskGroupId + "/tasks/" + taskId + "/details";
+        return "https://tools.taskcluster.net/groups/" + taskGroupId + "/tasks/" + taskId + "/runs/0/logs/public/logs/live.log";
     }
 }

--- a/src/main/java/org/mozilla/taskcluster/urls/LegacyURLs.java
+++ b/src/main/java/org/mozilla/taskcluster/urls/LegacyURLs.java
@@ -8,6 +8,7 @@ public class LegacyURLs implements URLProvider {
     /**
      * Generate URL for path in a Taskcluster service.
      */
+    @Override
     public String api(String service, String version, String path) {
         return "https://" + service + ".taskcluster.net/" + version + "/" + Clean.path(path);
     }
@@ -15,6 +16,7 @@ public class LegacyURLs implements URLProvider {
     /**
      * Generate URL for the api reference of a Taskcluster service.
      */
+    @Override
     public String apiReference(String service, String version) {
         return "https://references.taskcluster.net/" + service + "/" + version + "/api.json";
     }
@@ -22,6 +24,7 @@ public class LegacyURLs implements URLProvider {
     /**
      * Generate URL for path in the Taskcluster docs website.
      */
+    @Override
     public String docs(String path) {
         return "https://docs.taskcluster.net/" + Clean.path(path);
     }
@@ -29,6 +32,7 @@ public class LegacyURLs implements URLProvider {
     /**
      * Generate URL for the exchange reference of a Taskcluster service.
      */
+    @Override
     public String exchangeReference(String service, String version) {
         return "https://references.taskcluster.net/" + service + "/" + version + "/exchanges.json";
     }
@@ -37,6 +41,7 @@ public class LegacyURLs implements URLProvider {
      * Generate URL for the schemas of a Taskcluster service.
      * The schema usually have the version in its name i.e. "v1/whatever.json"
      */
+    @Override
     public String schema(String service, String schema) {
         return "https://schemas.taskcluster.net/" + service + "/" + Clean.path(schema);
     }
@@ -44,6 +49,7 @@ public class LegacyURLs implements URLProvider {
     /**
      * Generate URL for Taskcluser UI.
      */
+    @Override
     public String ui(String path) {
         return "https://tools.taskcluster.net/" + Clean.path(path);
     }
@@ -51,6 +57,7 @@ public class LegacyURLs implements URLProvider {
     /**
      * Returns a URL for the service manifest of a taskcluster deployment.
      */
+    @Override
     public String servicesManifest() {
         return "https://references.taskcluster.net/manifest.json";
     }
@@ -58,6 +65,7 @@ public class LegacyURLs implements URLProvider {
     /**
      * Returns a link to the task group in Task Inspector
      */
+    @Override
     public String taskInspector(String taskGroupId) {
         return "https://tools.taskcluster.net/groups/" + taskGroupId;
     }
@@ -65,6 +73,7 @@ public class LegacyURLs implements URLProvider {
     /**
      * Returns a link to the task in Task Inspector
      */
+    @Override
     public String taskInspector(String taskGroupId, String taskId) {
         return "https://tools.taskcluster.net/groups/" + taskGroupId + "/tasks/" + taskId + "/details";
     }

--- a/src/main/java/org/mozilla/taskcluster/urls/NewURLs.java
+++ b/src/main/java/org/mozilla/taskcluster/urls/NewURLs.java
@@ -60,4 +60,18 @@ public class NewURLs implements URLProvider {
     public String servicesManifest() {
         return this.rootURL + "/references/manifest.json";
     }
+
+    /**
+     * Returns a link to the task group in Task Inspector
+     */
+    public String taskInspector(String taskGroupId) {
+        return this.rootURL + "/groups/" + taskGroupId;
+    }
+
+    /**
+     * Returns a link to the task in Task Inspector
+     */
+    public String taskInspector(String taskGroupId, String taskId) {
+        return this.rootURL + "/groups/" + taskGroupId + "/tasks/" + taskId + "/details";
+    }
 }

--- a/src/main/java/org/mozilla/taskcluster/urls/NewURLs.java
+++ b/src/main/java/org/mozilla/taskcluster/urls/NewURLs.java
@@ -81,6 +81,6 @@ public class NewURLs implements URLProvider {
      */
     @Override
     public String taskInspector(String taskGroupId, String taskId) {
-        return this.rootURL + "/groups/" + taskGroupId + "/tasks/" + taskId + "/details";
+        return this.rootURL + "/groups/" + taskGroupId + "/tasks/" + taskId + "/runs/0/logs/public/logs/live.log";
     }
 }

--- a/src/main/java/org/mozilla/taskcluster/urls/NewURLs.java
+++ b/src/main/java/org/mozilla/taskcluster/urls/NewURLs.java
@@ -14,6 +14,7 @@ public class NewURLs implements URLProvider {
     /**
      * Generate URL for path in a Taskcluster service.
      */
+    @Override
     public String api(String service, String version, String path) {
         return this.rootURL + "/api/" + service + "/" + version + "/" + Clean.path(path);
     }
@@ -21,6 +22,7 @@ public class NewURLs implements URLProvider {
     /**
      * Generate URL for the api reference of a Taskcluster service.
      */
+    @Override
     public String apiReference(String service, String version) {
         return this.rootURL + "/references/" + service + "/" + version + "/api.json";
     }
@@ -28,6 +30,7 @@ public class NewURLs implements URLProvider {
     /**
      * Generate URL for path in the Taskcluster docs website.
      */
+    @Override
     public String docs(String path) {
         return this.rootURL + "/docs/" + Clean.path(path);
     }
@@ -35,6 +38,7 @@ public class NewURLs implements URLProvider {
     /**
      * Generate URL for the exchange reference of a Taskcluster service.
      */
+    @Override
     public String exchangeReference(String service, String version) {
         return this.rootURL + "/references/" + service + "/" + version + "/exchanges.json";
     }
@@ -43,6 +47,7 @@ public class NewURLs implements URLProvider {
      * Generate URL for the schemas of a Taskcluster service.
      * The schema usually have the version in its name i.e. "v1/whatever.json"
      */
+    @Override
     public String schema(String service, String schema) {
         return this.rootURL + "/schemas/" + service + "/" + Clean.path(schema);
     }
@@ -50,6 +55,7 @@ public class NewURLs implements URLProvider {
     /**
      * Generate URL for Taskcluser UI.
      */
+    @Override
     public String ui(String path) {
         return this.rootURL + "/" + Clean.path(path);
     }
@@ -57,6 +63,7 @@ public class NewURLs implements URLProvider {
     /**
      * Returns a URL for the service manifest of a taskcluster deployment.
      */
+    @Override
     public String servicesManifest() {
         return this.rootURL + "/references/manifest.json";
     }
@@ -64,6 +71,7 @@ public class NewURLs implements URLProvider {
     /**
      * Returns a link to the task group in Task Inspector
      */
+    @Override
     public String taskInspector(String taskGroupId) {
         return this.rootURL + "/groups/" + taskGroupId;
     }
@@ -71,6 +79,7 @@ public class NewURLs implements URLProvider {
     /**
      * Returns a link to the task in Task Inspector
      */
+    @Override
     public String taskInspector(String taskGroupId, String taskId) {
         return this.rootURL + "/groups/" + taskGroupId + "/tasks/" + taskId + "/details";
     }

--- a/src/main/java/org/mozilla/taskcluster/urls/URLProvider.java
+++ b/src/main/java/org/mozilla/taskcluster/urls/URLProvider.java
@@ -37,4 +37,14 @@ public interface URLProvider {
      * Returns a URL for the service manifest of a taskcluster deployment.
      */
     public String servicesManifest();
+
+    /**
+     * Returns a link to the task group in Task Inspector
+     */
+    public String taskInspector(String taskGroupId);
+
+    /**
+     * Returns a link to the task in Task Inspector
+     */
+    public String taskInspector(String taskGroupId, String taskId);
 }

--- a/src/test/java/org/mozilla/taskcluster/urls/URLsTest.java
+++ b/src/test/java/org/mozilla/taskcluster/urls/URLsTest.java
@@ -64,6 +64,9 @@ public class URLsTest {
             return urlProvider.ui(args[0]);
         case "servicesManifest":
             return urlProvider.servicesManifest();
+        case "taskInspector":
+            if (args.length == 1) return urlProvider.taskInspector(args[0]);
+            else return urlProvider.taskInspector(args[0], args[1]);
         default:
             throw new NoSuchMethodException("Unknown function type: " + function);
         }

--- a/taskcluster_urls/__init__.py
+++ b/taskcluster_urls/__init__.py
@@ -62,12 +62,9 @@ def services_manifest(root_url):
 
 def task_inspector(root_url, task_group, task_id = ''):
     """Returns a link to the task group or the task in Task Inspector."""
-    root_url = root_url.rstrip('/')
     task_logs = '/tasks/{}/runs/0/logs/public/logs/live.log'.format(task_id) if task_id else ''
-    if root_url == OLD_ROOT_URL:
-        return 'https://tools.taskcluster.net/groups/{}{}'.format(task_group, task_logs)
-    else:
-        return '{}/groups/{}{}'.format(root_url, task_group, task_logs)
+    url_second_part = 'groups/{}{}'.format(task_group, task_logs)
+    return ui(root_url, url_second_part)
 
 def test_root_url():
     """Returns a standardized "testing" rootUrl that does not resolve but

--- a/taskcluster_urls/__init__.py
+++ b/taskcluster_urls/__init__.py
@@ -63,11 +63,11 @@ def services_manifest(root_url):
 def task_inspector(root_url, task_group, task_id = ''):
     """Returns a link to the task group or the task in Task Inspector."""
     root_url = root_url.rstrip('/')
-    task_details = '/tasks/{}/details'.format(task_id) if task_id else ''
+    task_logs = '/tasks/{}/runs/0/logs/public/logs/live.log'.format(task_id) if task_id else ''
     if root_url == OLD_ROOT_URL:
-        return 'https://tools.taskcluster.net/groups/{}{}'.format(task_group, task_details)
+        return 'https://tools.taskcluster.net/groups/{}{}'.format(task_group, task_logs)
     else:
-        return '{}/groups/{}{}'.format(root_url, task_group, task_details)
+        return '{}/groups/{}{}'.format(root_url, task_group, task_logs)
 
 def test_root_url():
     """Returns a standardized "testing" rootUrl that does not resolve but

--- a/taskcluster_urls/__init__.py
+++ b/taskcluster_urls/__init__.py
@@ -60,6 +60,15 @@ def services_manifest(root_url):
     else:
         return '{}/references/manifest.json'.format(root_url)
 
+def task_inspector(root_url, task_group, task_id = ''):
+    """Returns a link to the task group or the task in Task Inspector."""
+    root_url = root_url.rstrip('/')
+    task_details = '/tasks/{}/details'.format(task_id) if task_id else ''
+    if root_url == OLD_ROOT_URL:
+        return 'https://tools.taskcluster.net/groups/{}{}'.format(task_group, task_details)
+    else:
+        return '{}/groups/{}{}'.format(root_url, task_group, task_details)
+
 def test_root_url():
     """Returns a standardized "testing" rootUrl that does not resolve but
     is easily recognizable in test failures."""

--- a/tcurls.go
+++ b/tcurls.go
@@ -80,3 +80,21 @@ func ServicesManifest(rootURL string) string {
 		return fmt.Sprintf("%s/references/manifest.json", r)
 	}
 }
+
+// Returns a link to the task group or the task in Task Inspector
+func TaskInspector(rootURL string, ids ...string) string {
+	taskGroupId := ids[0]
+	var taskDetails string
+	if len(ids) > 1 {
+		taskId := ids[1]
+		taskDetails = fmt.Sprintf("/tasks/%s/details", taskId)
+	} else {
+		taskDetails = ""
+	}
+	switch r := strings.TrimRight(rootURL, "/"); r {
+	case oldRootURL:
+		return "https://references.taskcluster.net/manifest.json"
+	default:
+		return fmt.Sprintf("%s/groups/%s%s", r, taskGroupId, taskDetails)
+	}
+}

--- a/tcurls.go
+++ b/tcurls.go
@@ -84,17 +84,17 @@ func ServicesManifest(rootURL string) string {
 // TaskInspector returns a link to the task group or the task in Task Inspector
 func TaskInspector(rootURL string, ids ...string) string {
 	taskGroupID := ids[0]
-	var taskDetails string
+	var taskLogs string
 	if len(ids) > 1 {
 		taskID := ids[1]
-		taskDetails = fmt.Sprintf("/tasks/%s/details", taskID)
+		taskLogs = fmt.Sprintf("/tasks/%s/runs/0/logs/public/logs/live.log", taskID)
 	} else {
-		taskDetails = ""
+		taskLogs = ""
 	}
 	switch r := strings.TrimRight(rootURL, "/"); r {
 	case oldRootURL:
 		return "https://references.taskcluster.net/manifest.json"
 	default:
-		return fmt.Sprintf("%s/groups/%s%s", r, taskGroupID, taskDetails)
+		return fmt.Sprintf("%s/groups/%s%s", r, taskGroupID, taskLogs)
 	}
 }

--- a/tcurls.go
+++ b/tcurls.go
@@ -81,13 +81,13 @@ func ServicesManifest(rootURL string) string {
 	}
 }
 
-// Returns a link to the task group or the task in Task Inspector
+// TaskInspector returns a link to the task group or the task in Task Inspector
 func TaskInspector(rootURL string, ids ...string) string {
-	taskGroupId := ids[0]
+	taskGroupID := ids[0]
 	var taskDetails string
 	if len(ids) > 1 {
-		taskId := ids[1]
-		taskDetails = fmt.Sprintf("/tasks/%s/details", taskId)
+		taskID := ids[1]
+		taskDetails = fmt.Sprintf("/tasks/%s/details", taskID)
 	} else {
 		taskDetails = ""
 	}
@@ -95,6 +95,6 @@ func TaskInspector(rootURL string, ids ...string) string {
 	case oldRootURL:
 		return "https://references.taskcluster.net/manifest.json"
 	default:
-		return fmt.Sprintf("%s/groups/%s%s", r, taskGroupId, taskDetails)
+		return fmt.Sprintf("%s/groups/%s%s", r, taskGroupID, taskDetails)
 	}
 }

--- a/tcurls.go
+++ b/tcurls.go
@@ -91,10 +91,6 @@ func TaskInspector(rootURL string, ids ...string) string {
 	} else {
 		taskLogs = ""
 	}
-	switch r := strings.TrimRight(rootURL, "/"); r {
-	case oldRootURL:
-		return "https://references.taskcluster.net/manifest.json"
-	default:
-		return fmt.Sprintf("%s/groups/%s%s", r, taskGroupID, taskLogs)
-	}
+	urlSecondPart := fmt.Sprintf("groups/%s%s", taskGroupID, taskLogs)
+	return UI(rootURL, urlSecondPart)
 }

--- a/tcurls_test.go
+++ b/tcurls_test.go
@@ -36,6 +36,12 @@ func testFunc(t *testing.T, function string, expectedURL string, root string, ar
 		actualURL = UI(root, args[0])
 	case "servicesManifest":
 		actualURL = ServicesManifest(root)
+	case "taskInspector":
+		if len(args) == 1 {
+			actualURL = TaskInspector(root, args[0])
+		} else {
+			actualURL = TaskInspector(root, args[0], args[1])
+		}
 	default:
 		t.Errorf("Unknown function type: %s", function)
 		return

--- a/test/basic_test.js
+++ b/test/basic_test.js
@@ -7,13 +7,16 @@ const libUrls = require('../');
 const SPEC_FILE = path.join(__dirname, '../tests.yml');
 
 suite('basic test', function() {
+
   var doc = yaml.safeLoad(fs.readFileSync(SPEC_FILE, {encoding: 'utf8'}));
-  for (let test of doc['tests']) {
-    for (let argSet of test['argSets']) {
+  for (let t of doc['tests']) {
+    for (let argSet of t['argSets']) {
       for (let cluster of Object.keys(doc['rootURLs'])) {
         for (let rootURL of doc['rootURLs'][cluster]) {
-          assert.equal(test['expected'][cluster], libUrls.withRootUrl(rootURL)[test['function']](...argSet));
-          assert.equal(test['expected'][cluster], libUrls[test['function']](rootURL, ...argSet));
+          test(`${t['function']} - ${argSet}`, function() {
+            assert.equal(t['expected'][cluster], libUrls.withRootUrl(rootURL)[t['function']](...argSet));
+            assert.equal(t['expected'][cluster], libUrls[t['function']](rootURL, ...argSet));  
+          });
         }
       }
     }

--- a/tests.yml
+++ b/tests.yml
@@ -138,9 +138,9 @@ tests:
   argSets:
   - [thisIsATaskGroupId, thisIsATaskId]
   expected:
-     old: https://tools.taskcluster.net/groups/thisIsATaskGroupId/tasks/thisIsATaskId/details
-     new: https://taskcluster.example.com/groups/thisIsATaskGroupId/tasks/thisIsATaskId/details
-     invalid: 12345/groups/thisIsATaskGroupId/tasks/thisIsATaskId/details
-     empty: /groups/thisIsATaskGroupId/tasks/thisIsATaskId/details
+     old: https://tools.taskcluster.net/groups/thisIsATaskGroupId/tasks/thisIsATaskId/runs/0/logs/public/logs/live.log
+     new: https://taskcluster.example.com/groups/thisIsATaskGroupId/tasks/thisIsATaskId/runs/0/logs/public/logs/live.log
+     invalid: 12345/groups/thisIsATaskGroupId/tasks/thisIsATaskId/runs/0/logs/public/logs/live.log
+     empty: /groups/thisIsATaskGroupId/tasks/thisIsATaskId/runs/0/logs/public/logs/live.log
 
 

--- a/tests.yml
+++ b/tests.yml
@@ -126,3 +126,21 @@ tests:
     new: https://taskcluster.example.com/references/manifest.json
     invalid: 12345/references/manifest.json
     empty: /references/manifest.json
+- function: taskInspector
+  argSets:
+  - [thisIsATaskGroupId]
+  expected:
+    old: https://tools.taskcluster.net/groups/thisIsATaskGroupId
+    new: https://taskcluster.example.com/groups/thisIsATaskGroupId
+    invalid: 12345/groups/thisIsATaskGroupId
+    empty: /groups/thisIsATaskGroupId
+- function: taskInspector
+  argSets:
+  - [thisIsATaskGroupId, thisIsATaskId]
+  expected:
+     old: https://tools.taskcluster.net/groups/thisIsATaskGroupId/tasks/thisIsATaskId/details
+     new: https://taskcluster.example.com/groups/thisIsATaskGroupId/tasks/thisIsATaskId/details
+     invalid: 12345/groups/thisIsATaskGroupId/tasks/thisIsATaskId/details
+     empty: /groups/thisIsATaskGroupId/tasks/thisIsATaskId/details
+
+


### PR DESCRIPTION
So yesterday I thought about the suggestion that @djmitche and @imbstack made in my tc-gh PR, about using this library to construct a URL instead of template literal. I'm fond of template literals and other primitive things for them being simple and easy to debug. However, it's true that in the context of microservices, it's hard to make changes if things are scattered around in assorted template literals - on this I agree with Dustin and Brian.

I don't like the suggested `ui` method because it's too generic, I think. I'd rather have url constructors for each service we have - that way, if we change the url shape, we will need to change what the corresponding method returns. The interface will remain the same, and so we would need to amend this library only. Whereas, in case of a generic function like `ui` - you still need to go to every microservice and check what we concatenate with `ui`... 

So I decided to go ahead and implement the method for constructing a url for task groups and tasks, which I need in my particular case.

Let me know what you think of this!